### PR TITLE
Store game kickoff times as UTC and serialize API dates with Z.

### DIFF
--- a/Mundialito/Controllers/GamesController.cs
+++ b/Mundialito/Controllers/GamesController.cs
@@ -146,7 +146,7 @@ public class GamesController : ControllerBase
             HomeTeamId = game.HomeTeam.TeamId,
             AwayTeamId = game.AwayTeam.TeamId,
             StadiumId = game.Stadium.StadiumId,
-            Date = game.Date,
+            Date = GameDateTime.ToUtc(game.Date),
             IntegrationsData = game.IntegrationsData,
             Type = game.Type
         };
@@ -176,7 +176,7 @@ public class GamesController : ControllerBase
         item.HomeScore = game.HomeScore;
         item.CardsMark = game.CardsMark;
         item.CornersMark = game.CornersMark;
-        item.Date = game.Date;
+        item.Date = GameDateTime.ToUtc(game.Date);
         item.IntegrationsData = game.IntegrationsData;
         item.Type = game.Type;
         gamesRepository.Save();

--- a/Mundialito/DAL/MundialitoDbContext.cs
+++ b/Mundialito/DAL/MundialitoDbContext.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Mundialito.Logic;
 using Mundialito.DAL.Accounts;
 using Mundialito.DAL.ActionLogs;
 using Mundialito.DAL.Bets;
@@ -57,6 +59,14 @@ public class MundialitoDbContext : IdentityDbContext<MundialitoUser>
 				.HasForeignKey(m => m.HomeTeamId)
 				.OnDelete(DeleteBehavior.NoAction)
 				.IsRequired();
+
+		var utcDateTimeConverter = new ValueConverter<DateTime, DateTime>(
+			v => GameDateTime.ToUtc(v),
+			v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+		modelBuilder.Entity<Game>()
+			.Property(g => g.Date)
+			.HasConversion(utcDateTimeConverter);
 
 		var dictionaryComparer = new ValueComparer<Dictionary<string, string>>(
 			(c1, c2) => JsonSerializer.Serialize(c1, (JsonSerializerOptions)null) == JsonSerializer.Serialize(c2, (JsonSerializerOptions)null),

--- a/Mundialito/DAL/TournamentCreators/Mundial2026.cs
+++ b/Mundialito/DAL/TournamentCreators/Mundial2026.cs
@@ -2,6 +2,7 @@ using Mundialito.DAL.Games;
 using Mundialito.DAL.Players;
 using Mundialito.DAL.Stadiums;
 using Mundialito.DAL.Teams;
+using Mundialito.Logic;
 
 namespace Mundialito.DAL.DBCreators;
 
@@ -192,9 +193,9 @@ public class Mundial2026 : ITournamentCreator
         };
     }
 
-    /// <summary>Kickoff in Israel local time (UTC+3). Values are pre-converted from the official FIFA schedule (US Eastern).</summary>
+    /// <summary>Israel local kickoff from FIFA schedule (US Eastern +7h), stored as UTC.</summary>
     private static DateTime IsraelKickoff(int year, int month, int day, int hour, int minute = 0) =>
-        new DateTime(year, month, day, hour, minute, 0);
+        GameDateTime.FromIsraelLocal(year, month, day, hour, minute);
 
     private static Game GroupGame(
         Dictionary<string, Team> teams,

--- a/Mundialito/Logic/GameDateTime.cs
+++ b/Mundialito/Logic/GameDateTime.cs
@@ -1,0 +1,25 @@
+namespace Mundialito.Logic;
+
+public static class GameDateTime
+{
+    private static readonly TimeZoneInfo IsraelTimeZone =
+        TimeZoneInfo.FindSystemTimeZoneById("Asia/Jerusalem");
+
+    /// <summary>DB and API convention: Unspecified values are UTC wall-clock.</summary>
+    public static DateTime ToUtc(DateTime value) =>
+        value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+
+    public static DateTime EnsureUtcKind(DateTime value) => ToUtc(value);
+
+    /// <summary>Converts Israel local wall-clock (from FIFA schedule) to UTC for storage.</summary>
+    public static DateTime FromIsraelLocal(int year, int month, int day, int hour, int minute = 0)
+    {
+        var local = new DateTime(year, month, day, hour, minute, 0, DateTimeKind.Unspecified);
+        return TimeZoneInfo.ConvertTimeToUtc(local, IsraelTimeZone);
+    }
+}

--- a/Mundialito/Logic/UtcDateTimeJsonConverter.cs
+++ b/Mundialito/Logic/UtcDateTimeJsonConverter.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Mundialito.Logic;
+
+public class UtcDateTimeJsonConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrEmpty(value))
+        {
+            return default;
+        }
+
+        var parsed = DateTime.Parse(value, null, System.Globalization.DateTimeStyles.RoundtripKind);
+        return GameDateTime.ToUtc(parsed);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(GameDateTime.ToUtc(value).ToString("o"));
+    }
+}
+
+public class NullableUtcDateTimeJsonConverter : JsonConverter<DateTime?>
+{
+    public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrEmpty(value))
+        {
+            return null;
+        }
+
+        var parsed = DateTime.Parse(value, null, System.Globalization.DateTimeStyles.RoundtripKind);
+        return GameDateTime.ToUtc(parsed);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+    {
+        if (!value.HasValue)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStringValue(GameDateTime.ToUtc(value.Value).ToString("o"));
+    }
+}

--- a/Mundialito/Models/BetsModels.cs
+++ b/Mundialito/Models/BetsModels.cs
@@ -2,6 +2,7 @@ using Mundialito.DAL.Accounts;
 using Mundialito.DAL.Bets;
 using Mundialito.DAL.Games;
 using Mundialito.DAL.Teams;
+using Mundialito.Logic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -202,7 +203,7 @@ public class BetGame
         HomeTeam = new BetGameTeam(game.HomeTeam);
         AwayTeam = new BetGameTeam(game.AwayTeam);
         IsOpen = game.IsOpen();
-        Date = game.Date.ToLocalTime();
+        Date = GameDateTime.ToUtc(game.Date);
     }
     [JsonPropertyName("GameId")]
     public int GameId { get; set; }

--- a/Mundialito/Models/GamesModels.cs
+++ b/Mundialito/Models/GamesModels.cs
@@ -1,6 +1,7 @@
 using Mundialito.DAL.Games;
 using Mundialito.DAL.Stadiums;
 using Mundialito.DAL.Teams;
+using Mundialito.Logic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -14,7 +15,7 @@ public class GameViewModel
         HomeTeam = new GameTeamModel(game.HomeTeam);
         AwayTeam = new GameTeamModel(game.AwayTeam);
         Type = game.Type;
-        Date = game.Date.ToLocalTime();
+        Date = GameDateTime.ToUtc(game.Date);
         HomeScore = game.HomeScore;
         AwayScore = game.AwayScore;
         CornersMark = game.CornersMark;

--- a/Mundialito/Program.cs
+++ b/Mundialito/Program.cs
@@ -35,6 +35,8 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 });
 builder.Services.AddControllers().AddJsonOptions(opt =>
 {
+	opt.JsonSerializerOptions.Converters.Add(new UtcDateTimeJsonConverter());
+	opt.JsonSerializerOptions.Converters.Add(new NullableUtcDateTimeJsonConverter());
 	opt.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
 	opt.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
 });

--- a/Tests/GameDateTimeTests.cs
+++ b/Tests/GameDateTimeTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Mundialito.Logic;
+
+namespace Tests;
+
+public class GameDateTimeTests
+{
+    [Test]
+    public void FromIsraelLocal_MexicoOpener_Is19Utc()
+    {
+        var utc = GameDateTime.FromIsraelLocal(2026, 6, 11, 22, 0);
+        Assert.That(utc.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(utc, Is.EqualTo(new DateTime(2026, 6, 11, 19, 0, 0, DateTimeKind.Utc)));
+    }
+
+    [Test]
+    public void ToUtc_Unspecified_TreatsAsUtcWallClock()
+    {
+        var unspecified = new DateTime(2026, 6, 11, 19, 0, 0, DateTimeKind.Unspecified);
+        var utc = GameDateTime.ToUtc(unspecified);
+        Assert.That(utc.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(utc.Hour, Is.EqualTo(19));
+    }
+
+    [Test]
+    public void JsonConverter_WritesUtcWithZ()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new UtcDateTimeJsonConverter());
+
+        var json = JsonSerializer.Serialize(new DateTime(2026, 6, 11, 19, 0, 0, DateTimeKind.Utc), options);
+        Assert.That(json, Does.Contain("2026-06-11T19:00:00"));
+        Assert.That(json, Does.EndWith("Z\""));
+    }
+}


### PR DESCRIPTION
Seed converts Israel FIFA times via FromIsraelLocal; remove ToLocalTime on read and normalize admin writes.